### PR TITLE
A few bug fixes

### DIFF
--- a/plantidbot.py
+++ b/plantidbot.py
@@ -32,12 +32,15 @@ async def main_loop():
             await join(s, COMMUNITY_ID)
 
             while True:
-                post = json.loads(await s.recv())
+                update = json.loads(await s.recv())
 
-                if (id := post['data']['post_view']['post']['id']) in processed:
+                if update['op'] != 'CreatePost':
                     continue
 
-                await handle_post(s, post, jwt)
+                if (id := update['data']['post_view']['post']['id']) in processed:
+                    continue
+
+                await handle_post(s, update, jwt)
 
                 processed.append(id)
                 dump_processed('processed.bin', processed)

--- a/plantidbot.py
+++ b/plantidbot.py
@@ -74,7 +74,7 @@ async def handle_post(s, post, jwt):
     for result in plant_id['results'][:5]:
         common_name = result['species']['commonNames'][0] if len(result['species']['commonNames']) != 0 else '/'
         scientific_name = result['species']['scientificNameWithoutAuthor']
-        score = result['score']
+        score = format(result['score'] * 100, '.2f')
 
         table += f'|{common_name}|{scientific_name}|{score} %|\n'
 


### PR DESCRIPTION
I think the duplicate replies were caused by the fact that the bot was treating all updates from Lemmy's API as if they were new posts, when in reality some of them were just posts being upvoted. I've added a check to filter out everything except updates about new posts and renamed the `post` variable to `update`, as I think it's less confusing.

I also fixed the likeliness scores, which were 100x smaller than they should have been, and formatted them so that only 2 decimal places are shown.